### PR TITLE
Bump Python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-CherryPy==18.6.0
-glustercli==0.8.0
+CherryPy==18.8.0
+glustercli==0.8.3


### PR DESCRIPTION
* Update gluster cli to latest version which shoud fix #42 
* Bump CherryPy to latest version

Would it be possible to get a new release of gdash on pypi once this is merge? 