### PR TITLE
Add support for deploying Gdash with SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Other available options are
 ```
 $ gdash --help
 usage: gdash [-h] [--version] [--port PORT] [--gluster-binary GLUSTER_BINARY]
-             [--auth-file AUTH_FILE]
+             [--auth-file AUTH_FILE] [--ssl-cert CERT_FILE] [--ssl-key KEY_FILE] [--ssl-ca CA_FILE]
              host
 
 gdash - GlusterFS Dashboard
@@ -65,6 +65,9 @@ optional arguments:
   --auth-file AUTH_FILE            Users Credentials file. One user
                                    entry per row in the
                                    format <username>=<password_hash>
+  --ssl-cert CERT_FILE             Path to SSL Certificate file
+  --ssl-key KEY_FILE               Path to SSL Key file
+  --ssl-ca CA_FILE                 Path to SSL CA Certificate file
 ```
 
 ## Blog

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Other available options are
 ```
 $ gdash --help
 usage: gdash [-h] [--version] [--port PORT] [--gluster-binary GLUSTER_BINARY]
-             [--auth-file AUTH_FILE] [--ssl-cert CERT_FILE] [--ssl-key KEY_FILE] [--ssl-ca CA_FILE]
+             [--auth-file AUTH_FILE] [--ssl-cert CERT_FILE] [--ssl-key KEY_FILE] [--ssl-ca CA_CERT_FILE]
              host
 
 gdash - GlusterFS Dashboard

--- a/gdash/__main__.py
+++ b/gdash/__main__.py
@@ -167,6 +167,18 @@ def get_args():
         help=('Users Credentials file. One user entry per row '
               'in the format <username>=<password_hash>')
     )
+    parser.add_argument('--ssl-cert',
+        default=None,
+        help=('Path to SSL Certificate used by Gdash')
+    )
+    parser.add_argument('--ssl-key',
+        default=None,
+        help=('Path to SSL Key used by Gdash')
+    )
+    parser.add_argument('--ssl-ca',
+        default=None,
+        help=('Path to SSL CA Certificate used by Gdash')
+    )
 
     return parser.parse_args()
 
@@ -187,10 +199,24 @@ def main():
 
     set_gluster_path(args.gluster_binary)
 
-    cherrypy.config.update({
+    cherrypy_config = {
         'server.socket_host': '0.0.0.0',
         'server.socket_port': args.port
-    })
+    }
+
+    if args.ssl_cert:
+        cherrypy_config['server.ssl_certificate'] = args.ssl_cert
+
+    if args.ssl_key:
+        cherrypy_config['server.ssl_private_key'] = args.ssl_key
+
+    if args.ssl_ca:
+        cherrypy_config['server.ssl_certificate_chain'] = args.ssl_ca
+
+    if args.ssl_cert and args.ssl_key:
+        cherrypy_config['server.ssl_module'] = 'builtin'
+
+    cherrypy.config.update(cherrypy_config)
     webapp = GdashWeb()
     webapp.api = GdashApis()
     cherrypy.quickstart(webapp, '/', conf)

--- a/gdash/__main__.py
+++ b/gdash/__main__.py
@@ -199,24 +199,24 @@ def main():
 
     set_gluster_path(args.gluster_binary)
 
-    cherrypy_config = {
+    cherrypy_cfg = {
         'server.socket_host': '0.0.0.0',
         'server.socket_port': args.port
     }
 
     if args.ssl_cert:
-        cherrypy_config['server.ssl_certificate'] = args.ssl_cert
+        cherrypy_cfg['server.ssl_certificate'] = args.ssl_cert
 
     if args.ssl_key:
-        cherrypy_config['server.ssl_private_key'] = args.ssl_key
+        cherrypy_cfg['server.ssl_private_key'] = args.ssl_key
 
     if args.ssl_ca:
-        cherrypy_config['server.ssl_certificate_chain'] = args.ssl_ca
+        cherrypy_cfg['server.ssl_certificate_chain'] = args.ssl_ca
 
     if args.ssl_cert and args.ssl_key:
-        cherrypy_config['server.ssl_module'] = 'builtin'
+        cherrypy_cfg['server.ssl_module'] = 'builtin'
 
-    cherrypy.config.update(cherrypy_config)
+    cherrypy.config.update(cherrypy_cfg)
     webapp = GdashWeb()
     webapp.api = GdashApis()
     cherrypy.quickstart(webapp, '/', conf)


### PR DESCRIPTION
The main purpose of this PR is to add support for deploying Gdash using the builtin cherrypy SSL Support.

The following args were added: 

```
--ssl-cert
--ssl-key
--ssl-ca
```

Changes based on: https://docs.cherrypy.dev/en/latest/deploy.html?highlight=ssl#ssl-support

Signed-off-by: Juan Calderon [jgcalderonperez@protonmail.com](mailto:jgcalderonperez@protonmail.com)