### PR TITLE
Bump glustercli to v0.8.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 CherryPy==18.8.0
-glustercli==0.8.3
+glustercli==0.8.6


### PR DESCRIPTION
Minor patch update for glustercli python dependency